### PR TITLE
Turn Resource into a macro

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -292,6 +292,7 @@ dependencies = [
  "monostate",
  "partial_id",
  "rand",
+ "resource",
  "serde",
  "serde_json",
  "serde_repr",
@@ -948,6 +949,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "567664f262709473930a4bf9e51bf2ebf3348f2e748ccc50dea20646858f8f29"
 dependencies = [
  "bitflags 1.3.2",
+]
+
+[[package]]
+name = "resource"
+version = "0.1.0"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,6 +2,7 @@
 name = "cardmaster"
 version = "0.1.0"
 edition = "2021"
+authors = [ "Astavie <astavie@pm.me>" ]
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/discord/Cargo.toml
+++ b/discord/Cargo.toml
@@ -2,6 +2,7 @@
 name = "discord"
 version = "0.1.0"
 edition = "2021"
+authors = [ "Astavie <astavie@pm.me>" ]
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
@@ -11,7 +12,6 @@ isahc = { version = "1.7.2", features = ["serde_json", "json"] }
 serde = { version = "1.0.126", features = ["derive"] }
 serde_json = "1.0.96"
 tokio = { version = "1.27.0", features = ["full"] }
-partial_id = { path = "partial_id" }
 serde_repr = "0.1.12"
 tokio-tungstenite = { version = "0.18.0", features = ["native-tls"] }
 futures-util = "0.3.28"
@@ -20,6 +20,9 @@ tokio-stream = "0.1.14"
 async-trait = "0.1.68"
 enumset = { version = "1.1.2", features = ["serde"] }
 monostate = "0.1.6"
+
+partial_id = { path = "partial_id" }
+resource = { path = "resource" }
 
 [patch.crates-io]
 serde = { git = "https://github.com/Astavie/serde.git", branch = "integer-tags-for-enums-noprecompile" }

--- a/discord/partial_id/src/lib.rs
+++ b/discord/partial_id/src/lib.rs
@@ -24,12 +24,18 @@ pub fn derive_partial(input: proc_macro::TokenStream) -> proc_macro::TokenStream
     } else {
         proc_macro2::TokenStream::from_iter(derives.into_iter())
     };
-    let partial_ident = Ident::new(&format!("Partial{}", ty), Span::call_site());
+    let partial_ty = Ident::new(&format!("Partial{}", ty), Span::call_site());
 
     let fields = filter_fields(match data {
         syn::Data::Struct(ref s) => &s.fields,
         _ => panic!("Field can only be derived for structs"),
     });
+
+    let id_typ = &fields
+        .iter()
+        .find(|(_, ident, _)| ident.to_string() == "id")
+        .unwrap()
+        .2;
 
     let field_var = fields.iter().map(|(vis, ident, ty)| {
         if ident.to_string() == "id" {
@@ -53,24 +59,74 @@ pub fn derive_partial(input: proc_macro::TokenStream) -> proc_macro::TokenStream
             }
         }
     });
+    let convert_none_branch = fields.iter().map(|(_vis, ident, _ty)| {
+        if ident.to_string() == "id" {
+            quote! {
+                #ident: src
+            }
+        } else {
+            quote! {
+                #ident: ::core::option::Option::None
+            }
+        }
+    });
 
     let (impl_generics, ty_generics, where_clause) = generics.split_for_impl();
 
     let tokens = quote! {
+
         #derive
-        #vis struct #partial_ident #ty_generics
-            #where_clause
-        {
+        #vis struct #partial_ty #generics {
             #(#field_var),*
         }
 
-        impl #impl_generics ::core::convert::From<#ty #ty_generics> for #partial_ident #ty_generics
+        impl #impl_generics ::core::convert::From<#ty #ty_generics> for #partial_ty #ty_generics
             #where_clause
         {
-            fn from(src: #ty #ty_generics) -> #partial_ident #ty_generics {
-                #partial_ident {
+            fn from(src: #ty #ty_generics) -> Self {
+                Self {
                     #(#convert_branch),*
                 }
+            }
+        }
+
+        impl #impl_generics ::core::convert::From<#id_typ> for #partial_ty #ty_generics
+            #where_clause
+        {
+            fn from(src: #id_typ) -> Self {
+                Self {
+                    #(#convert_none_branch),*
+                }
+            }
+        }
+
+        impl #impl_generics #ty #ty_generics
+            #where_clause
+        {
+            #vis async fn update(&mut self, client: &crate::request::Discord) -> crate::request::Result<()> {
+                *self = crate::request::Request::request(crate::request::HttpRequest::get(crate::resource::Endpoint::uri(&self.id)), client).await?;
+                crate::request::Result::Ok(())
+            }
+        }
+
+        impl #impl_generics #partial_ty #ty_generics
+            #where_clause
+        {
+            #vis async fn update(&mut self, client: &crate::request::Discord) -> crate::request::Result<()> {
+                let full: #ty = crate::request::Request::request(crate::request::HttpRequest::get(crate::resource::Endpoint::uri(&self.id)), client).await?;
+                *self = full.into();
+                crate::request::Result::Ok(())
+            }
+            #vis async fn get_field<T>(&mut self, client: &crate::request::Discord, f: fn(&Self) -> &::core::option::Option<T>) -> crate::request::Result<&T> {
+                crate::request::Result::Ok(match f(self) {
+                    ::core::option::Option::Some(_) => {
+                        f(self).as_ref().unwrap()
+                    }
+                    ::core::option::Option::None => {
+                        self.update(client).await?;
+                        f(self).as_ref().unwrap()
+                    }
+                })
             }
         }
     };

--- a/discord/partial_id/src/lib.rs
+++ b/discord/partial_id/src/lib.rs
@@ -54,35 +54,6 @@ pub fn derive_partial(input: proc_macro::TokenStream) -> proc_macro::TokenStream
         }
     });
 
-    let get_field = fields.iter().map(|(vis, ident, ty)| {
-        if ident.to_string() == "id" {
-            quote!{}
-        } else {
-            let get_ident = Ident::new(&format!("get_{}", ident), ident.span());
-            let get_ident_mut = Ident::new(&format!("get_{}_mut", ident), ident.span());
-            quote! {
-                #vis async fn #get_ident(&mut self, client: &crate::request::Discord) -> crate::request::Result<&#ty> {
-                    crate::request::Result::Ok(match self.#ident {
-                        ::core::option::Option::Some(ref v) => v,
-                        ::core::option::Option::None => {
-                            crate::resource::Updatable::update(self, client).await?;
-                            self.#ident.as_ref().unwrap()
-                        }
-                    })
-                }
-                #vis async fn #get_ident_mut(&mut self, client: &crate::request::Discord) -> crate::request::Result<&mut #ty> {
-                    crate::request::Result::Ok(match self.#ident {
-                        ::core::option::Option::Some(ref mut v) => v,
-                        ::core::option::Option::None => {
-                            crate::resource::Updatable::update(self, client).await?;
-                            self.#ident.as_mut().unwrap()
-                        }
-                    })
-                }
-            }
-        }
-    });
-
     let (impl_generics, ty_generics, where_clause) = generics.split_for_impl();
 
     let tokens = quote! {
@@ -101,12 +72,6 @@ pub fn derive_partial(input: proc_macro::TokenStream) -> proc_macro::TokenStream
                     #(#convert_branch),*
                 }
             }
-        }
-
-        impl #impl_generics #partial_ident #ty_generics
-            #where_clause
-        {
-            #(#get_field)*
         }
     };
     tokens.into()

--- a/discord/resource/Cargo.toml
+++ b/discord/resource/Cargo.toml
@@ -1,0 +1,16 @@
+[package]
+name = "resource"
+version = "0.1.0"
+edition = "2021"
+authors = [ "Astavie <astavie@pm.me>" ]
+
+[lib]
+proc-macro = true
+
+[dependencies]
+syn = { version = "~1.0", features = ["full"] }
+quote = "~1.0"
+proc-macro2 = "~1.0"
+
+[dev-dependencies]
+trybuild = "~1.0"

--- a/discord/resource/src/lib.rs
+++ b/discord/resource/src/lib.rs
@@ -1,0 +1,115 @@
+use proc_macro::TokenStream;
+use proc_macro2::{Ident, TokenStream as TokenStream2};
+use quote::quote;
+use syn::{
+    parse::{Parse, ParseStream},
+    parse_quote,
+    spanned::Spanned,
+    FnArg, ItemFn, ReturnType, Token, Type,
+};
+
+struct ResourceParams {
+    result: Type,
+    client: Option<Type>,
+}
+
+impl Parse for ResourceParams {
+    fn parse(input: ParseStream) -> syn::Result<Self> {
+        let result = input.parse()?;
+        let client = if input.peek(Token![,]) {
+            input.parse::<Token![,]>()?;
+
+            let ident: Ident = input.parse()?;
+            if ident.to_string() != "client" {
+                return Err(syn::Error::new(ident.span(), "invalid resource property"));
+            }
+
+            input.parse::<Token![=]>()?;
+            Some(input.parse()?)
+        } else {
+            None
+        };
+
+        Ok(Self { result, client })
+    }
+}
+
+fn resource_impl(attr: TokenStream, item: TokenStream) -> syn::Result<TokenStream2> {
+    let params: ResourceParams = syn::parse(attr)?;
+    let return_type = params.result;
+    let client_type = match params.client {
+        Some(t) => t,
+        None => parse_quote!(crate::request::Discord),
+    };
+
+    let result_type = parse_quote!(
+        ::std::pin::Pin<::std::boxed::Box<dyn ::futures_util::Future<Output = crate::request::Result<#return_type>> + ::std::marker::Send + 'resource>>
+    );
+
+    let mut get_request_fn: ItemFn = syn::parse(item)?;
+
+    // get immediate fn signature
+    let vis = get_request_fn.vis.clone();
+
+    let mut sig = get_request_fn.sig.clone();
+    let generic_params = sig.generics.params;
+    sig.generics = parse_quote!(<'resource, #generic_params>);
+    match &mut sig.output {
+        ReturnType::Default => panic!(),
+        ReturnType::Type(_, typ) => **typ = result_type,
+    }
+
+    // remove pattern matching from inputs and get names
+    let inputs = sig
+        .inputs
+        .iter_mut()
+        .skip(1) // skip self
+        .enumerate()
+        .map(|(n, arg)| match arg {
+            FnArg::Receiver(_) => panic!(),
+            FnArg::Typed(pt) => {
+                let ty = &*pt.ty;
+                match &*pt.pat {
+                    syn::Pat::Ident(ident) => {
+                        let id = &ident.ident;
+                        let id_cloned = id.clone();
+                        *arg = parse_quote!(#id: #ty);
+                        id_cloned
+                    }
+                    _ => {
+                        let id = Ident::new(&format!("arg__{}", n), pt.pat.span());
+                        let id_cloned = id.clone();
+                        *arg = parse_quote!(#id: #ty);
+                        id_cloned
+                    }
+                }
+            }
+        })
+        .collect::<Vec<_>>();
+
+    // insert client as input
+    sig.inputs
+        .insert(1, parse_quote!(client: &'resource #client_type));
+
+    // set original fn name to {}_request
+    let get_ident = get_request_fn.sig.ident;
+    let get_request_ident = Ident::new(&format!("{}_request", get_ident), get_ident.span());
+    get_request_fn.sig.ident = get_request_ident.clone();
+
+    // return functions
+    let tokens = quote! {
+        #get_request_fn
+        #vis #sig {
+            crate::request::Request::request(self.#get_request_ident(#(#inputs),*), client)
+        }
+    };
+    Ok(tokens)
+}
+
+#[proc_macro_attribute]
+pub fn resource(attr: TokenStream, item: TokenStream) -> TokenStream {
+    match resource_impl(attr, item) {
+        Ok(params) => params.into(),
+        Err(e) => return e.into_compile_error().into(),
+    }
+}

--- a/discord/src/application.rs
+++ b/discord/src/application.rs
@@ -2,8 +2,8 @@ use partial_id::Partial;
 use serde::Deserialize;
 
 use crate::guild::GuildResource;
-use crate::request::{Discord, Request};
-use crate::resource::resource;
+use crate::request::{Discord, HttpRequest};
+use crate::resource::{resource, Endpoint};
 
 use super::{command::Commands, resource::Snowflake};
 
@@ -35,6 +35,13 @@ impl ApplicationResource for Application {
     }
 }
 
+impl Endpoint for Snowflake<Application> {
+    fn uri(&self) -> String {
+        // you can only ever get your own application data
+        "/applications/@me".into()
+    }
+}
+
 pub struct Me;
 
 resource! {
@@ -42,6 +49,6 @@ resource! {
     use Discord;
 
     fn get(&self) -> Application {
-        Request::get("/oauth2/applications/@me")
+        HttpRequest::get("/applications/@me")
     }
 }

--- a/discord/src/application.rs
+++ b/discord/src/application.rs
@@ -2,7 +2,7 @@ use partial_id::Partial;
 use serde::Deserialize;
 
 use crate::guild::GuildResource;
-use crate::request::{Discord, HttpRequest};
+use crate::request::HttpRequest;
 use crate::resource::{resource, Endpoint};
 
 use super::{command::Commands, resource::Snowflake};
@@ -44,11 +44,9 @@ impl Endpoint for Snowflake<Application> {
 
 pub struct Me;
 
-resource! {
-    ApplicationMeResource as Me;
-    use Discord;
-
-    fn get(&self) -> Application {
+impl Me {
+    #[resource(Application)]
+    pub fn get(&self) -> HttpRequest<Application> {
         HttpRequest::get("/applications/@me")
     }
 }

--- a/discord/src/application.rs
+++ b/discord/src/application.rs
@@ -1,8 +1,9 @@
 use partial_id::Partial;
 use serde::Deserialize;
 
-use crate::guild::Guild;
-use crate::resource::{Endpoint, Resource};
+use crate::guild::GuildResource;
+use crate::request::{Discord, Request};
+use crate::resource::resource;
 
 use super::{command::Commands, resource::Snowflake};
 
@@ -18,7 +19,7 @@ pub trait ApplicationResource {
     fn global_commands(&self) -> Commands {
         Commands::new(self.endpoint().clone(), None)
     }
-    fn guild_commands(&self, guild: &impl Resource<Endpoint = Snowflake<Guild>>) -> Commands {
+    fn guild_commands(&self, guild: &impl GuildResource) -> Commands {
         Commands::new(self.endpoint().clone(), Some(guild.endpoint().clone()))
     }
 }
@@ -36,9 +37,11 @@ impl ApplicationResource for Application {
 
 pub struct Me;
 
-impl Endpoint for Me {
-    type Result = Application;
-    fn uri(&self) -> String {
-        "/oauth2/applications/@me".into()
+resource! {
+    ApplicationMeResource as Me;
+    use Discord;
+
+    fn get(&self) -> Application {
+        Request::get("/oauth2/applications/@me")
     }
 }

--- a/discord/src/channel.rs
+++ b/discord/src/channel.rs
@@ -5,11 +5,11 @@ use partial_id::Partial;
 use serde::Deserialize;
 
 use crate::request::Discord;
-use crate::resource::resource;
+use crate::resource::{resource, Endpoint};
 
 use super::{
     message::{CreateMessage, Message},
-    request::Request,
+    request::HttpRequest,
     resource::Snowflake,
 };
 
@@ -25,7 +25,7 @@ impl Display for Snowflake<Channel> {
     }
 }
 
-impl Snowflake<Channel> {
+impl Endpoint for Snowflake<Channel> {
     fn uri(&self) -> String {
         format!("/channels/{}", self.as_int())
     }
@@ -36,10 +36,10 @@ resource! {
     use Discord;
 
     fn get(&self) -> Channel {
-        Request::get(self.endpoint().uri())
+        HttpRequest::get(self.endpoint().uri())
     }
     fn send_message(&self, data: CreateMessage) -> Message {
-        Request::post(format!("{}/messages", self.endpoint().uri()), &data)
+        HttpRequest::post(format!("{}/messages", self.endpoint().uri()), &data)
     }
 }
 

--- a/discord/src/channel.rs
+++ b/discord/src/channel.rs
@@ -4,7 +4,6 @@ use std::write;
 use partial_id::Partial;
 use serde::Deserialize;
 
-use crate::request::Discord;
 use crate::resource::{resource, Endpoint};
 
 use super::{
@@ -31,26 +30,33 @@ impl Endpoint for Snowflake<Channel> {
     }
 }
 
-resource! {
-    ChannelResource as Snowflake<Channel>;
-    use Discord;
+pub trait ChannelResource {
+    fn endpoint(&self) -> Snowflake<Channel>;
 
-    fn get(&self) -> Channel {
+    #[resource(Channel)]
+    fn get(&self) -> HttpRequest<Channel> {
         HttpRequest::get(self.endpoint().uri())
     }
-    fn send_message(&self, data: CreateMessage) -> Message {
+    #[resource(Message)]
+    fn send_message(&self, data: CreateMessage) -> HttpRequest<Message> {
         HttpRequest::post(format!("{}/messages", self.endpoint().uri()), &data)
     }
 }
 
+impl ChannelResource for Snowflake<Channel> {
+    fn endpoint(&self) -> Snowflake<Channel> {
+        self.clone()
+    }
+}
+
 impl ChannelResource for Channel {
-    fn endpoint(&self) -> &Snowflake<Channel> {
-        &self.id
+    fn endpoint(&self) -> Snowflake<Channel> {
+        self.id
     }
 }
 
 impl ChannelResource for PartialChannel {
-    fn endpoint(&self) -> &Snowflake<Channel> {
-        &self.id
+    fn endpoint(&self) -> Snowflake<Channel> {
+        self.id
     }
 }

--- a/discord/src/command.rs
+++ b/discord/src/command.rs
@@ -3,8 +3,9 @@ use serde::{Deserialize, Serialize};
 use serde_repr::{Deserialize_repr, Serialize_repr};
 
 use crate::request::Discord;
-use crate::request::Request;
+use crate::request::HttpRequest;
 use crate::resource::resource;
+use crate::resource::Endpoint;
 
 use super::{application::Application, guild::Guild, resource::Snowflake};
 
@@ -168,8 +169,8 @@ impl Commands {
     }
 }
 
-impl Commands {
-    pub fn uri(&self) -> String {
+impl Endpoint for Commands {
+    fn uri(&self) -> String {
         if let Some(guild) = self.guild_id {
             format!(
                 "/applications/{}/guilds/{}/commands",
@@ -182,8 +183,8 @@ impl Commands {
     }
 }
 
-impl CommandIdentifier {
-    pub fn uri(&self) -> String {
+impl Endpoint for CommandIdentifier {
+    fn uri(&self) -> String {
         format!("{}/{}", self.command_pool.uri(), self.command_id.as_int())
     }
 }
@@ -193,10 +194,10 @@ resource! {
     use Discord;
 
     fn all(&self) -> Vec<Command> {
-        Request::get(self.endpoint().uri())
+        HttpRequest::get(self.endpoint().uri())
     }
     fn create(&self, data: CommandData) -> Command {
-        Request::post(self.endpoint().uri(), &data)
+        HttpRequest::post(self.endpoint().uri(), &data)
     }
 }
 
@@ -205,10 +206,10 @@ resource! {
     use Discord;
 
     fn get(&self) -> Command {
-        Request::get(self.endpoint().uri())
+        HttpRequest::get(self.endpoint().uri())
     }
     fn delete(mut self) -> () {
-        Request::delete(self.endpoint().uri())
+        HttpRequest::delete(self.endpoint().uri())
     }
 }
 

--- a/discord/src/gateway.rs
+++ b/discord/src/gateway.rs
@@ -215,7 +215,7 @@ const NAME: &str = env!("CARGO_PKG_NAME");
 
 impl Gateway {
     pub async fn connect(client: &Discord) -> request::Result<Self> {
-        let GatewayResponse { url } = Request::get("/gateway".into()).request(client).await?;
+        let GatewayResponse { url } = Request::get("/gateway").request(client).await?;
         let full_url = url + "/?v=10&encoding=json";
 
         let (mut ws_stream, _) = connect_async(full_url).await.expect("could not connect");

--- a/discord/src/gateway.rs
+++ b/discord/src/gateway.rs
@@ -18,7 +18,9 @@ use tokio::{
 use tokio_stream::wrappers::ReceiverStream;
 use tokio_tungstenite::{connect_async, tungstenite::Message, MaybeTlsStream, WebSocketStream};
 
-use super::request::{self, Request, RequestError};
+use crate::request::Request;
+
+use super::request::{self, HttpRequest, RequestError};
 use super::{interaction::AnyInteraction, request::Discord};
 
 struct GatewayState {
@@ -215,7 +217,7 @@ const NAME: &str = env!("CARGO_PKG_NAME");
 
 impl Gateway {
     pub async fn connect(client: &Discord) -> request::Result<Self> {
-        let GatewayResponse { url } = Request::get("/gateway").request(client).await?;
+        let GatewayResponse { url } = HttpRequest::get("/gateway").request(client).await?;
         let full_url = url + "/?v=10&encoding=json";
 
         let (mut ws_stream, _) = connect_async(full_url).await.expect("could not connect");

--- a/discord/src/guild.rs
+++ b/discord/src/guild.rs
@@ -1,9 +1,11 @@
 use partial_id::Partial;
 use serde::Deserialize;
 
-use crate::resource::Endpoint;
+use crate::request::Discord;
+use crate::request::Request;
+use crate::resource::resource;
 
-use super::resource::{Resource, Snowflake};
+use super::resource::Snowflake;
 
 #[derive(Partial)]
 #[derive(Debug, Deserialize)]
@@ -12,22 +14,29 @@ pub struct Guild {
     pub name: String,
 }
 
-impl Endpoint for Snowflake<Guild> {
-    type Result = Guild;
-    fn uri(&self) -> String {
+impl Snowflake<Guild> {
+    pub fn uri(&self) -> String {
         format!("/guilds/{}", self.as_int())
     }
 }
 
-impl Resource for Guild {
-    type Endpoint = Snowflake<Guild>;
-    fn endpoint(&self) -> &Self::Endpoint {
+resource! {
+    GuildResource as Snowflake<Guild>;
+    use Discord;
+
+    fn get(&self) -> Guild {
+        Request::get(self.endpoint().uri())
+    }
+}
+
+impl GuildResource for Guild {
+    fn endpoint(&self) -> &Snowflake<Guild> {
         &self.id
     }
 }
-impl Resource for PartialGuild {
-    type Endpoint = Snowflake<Guild>;
-    fn endpoint(&self) -> &Self::Endpoint {
+
+impl GuildResource for PartialGuild {
+    fn endpoint(&self) -> &Snowflake<Guild> {
         &self.id
     }
 }

--- a/discord/src/guild.rs
+++ b/discord/src/guild.rs
@@ -2,8 +2,9 @@ use partial_id::Partial;
 use serde::Deserialize;
 
 use crate::request::Discord;
-use crate::request::Request;
+use crate::request::HttpRequest;
 use crate::resource::resource;
+use crate::resource::Endpoint;
 
 use super::resource::Snowflake;
 
@@ -14,8 +15,8 @@ pub struct Guild {
     pub name: String,
 }
 
-impl Snowflake<Guild> {
-    pub fn uri(&self) -> String {
+impl Endpoint for Snowflake<Guild> {
+    fn uri(&self) -> String {
         format!("/guilds/{}", self.as_int())
     }
 }
@@ -25,7 +26,7 @@ resource! {
     use Discord;
 
     fn get(&self) -> Guild {
-        Request::get(self.endpoint().uri())
+        HttpRequest::get(self.endpoint().uri())
     }
 }
 

--- a/discord/src/guild.rs
+++ b/discord/src/guild.rs
@@ -1,7 +1,6 @@
 use partial_id::Partial;
 use serde::Deserialize;
 
-use crate::request::Discord;
 use crate::request::HttpRequest;
 use crate::resource::resource;
 use crate::resource::Endpoint;
@@ -21,23 +20,29 @@ impl Endpoint for Snowflake<Guild> {
     }
 }
 
-resource! {
-    GuildResource as Snowflake<Guild>;
-    use Discord;
+pub trait GuildResource {
+    fn endpoint(&self) -> Snowflake<Guild>;
 
-    fn get(&self) -> Guild {
+    #[resource(Guild)]
+    fn get(&self) -> HttpRequest<Guild> {
         HttpRequest::get(self.endpoint().uri())
     }
 }
 
+impl GuildResource for Snowflake<Guild> {
+    fn endpoint(&self) -> Snowflake<Guild> {
+        self.clone()
+    }
+}
+
 impl GuildResource for Guild {
-    fn endpoint(&self) -> &Snowflake<Guild> {
-        &self.id
+    fn endpoint(&self) -> Snowflake<Guild> {
+        self.id
     }
 }
 
 impl GuildResource for PartialGuild {
-    fn endpoint(&self) -> &Snowflake<Guild> {
-        &self.id
+    fn endpoint(&self) -> Snowflake<Guild> {
+        self.id
     }
 }

--- a/discord/src/interaction.rs
+++ b/discord/src/interaction.rs
@@ -193,31 +193,29 @@ pub struct ResponseRequest(HttpRequest<(), Webhook>, InteractionResponseIdentifi
 pub struct MessageResponseRequest(HttpRequest<Message, Webhook>, InteractionResponseIdentifier);
 
 #[async_trait]
-impl Request for ResponseRequest {
+impl Request<Webhook> for ResponseRequest {
     type Output = InteractionResponseIdentifier;
-    type Client = Webhook;
 
-    async fn request_weak(self, client: &Self::Client) -> Result<Self::Output> {
+    async fn request_weak(self, client: &Webhook) -> Result<Self::Output> {
         self.0.request_weak(client).await?;
         Ok(self.1)
     }
-    async fn request(self, client: &Self::Client) -> Result<Self::Output> {
+    async fn request(self, client: &Webhook) -> Result<Self::Output> {
         self.0.request(client).await?;
         Ok(self.1)
     }
 }
 
 #[async_trait]
-impl Request for MessageResponseRequest {
+impl Request<Webhook> for MessageResponseRequest {
     type Output = (InteractionResponseIdentifier, Message);
-    type Client = Webhook;
 
-    async fn request_weak(mut self, client: &Self::Client) -> Result<Self::Output> {
+    async fn request_weak(mut self, client: &Webhook) -> Result<Self::Output> {
         let m = self.0.request_weak(client).await?;
         self.1.message = Some(m.id.snowflake());
         Ok((self.1, m))
     }
-    async fn request(mut self, client: &Self::Client) -> Result<Self::Output> {
+    async fn request(mut self, client: &Webhook) -> Result<Self::Output> {
         let m = self.0.request(client).await?;
         self.1.message = Some(m.id.snowflake());
         Ok((self.1, m))

--- a/discord/src/lib.rs
+++ b/discord/src/lib.rs
@@ -1,5 +1,4 @@
 #![feature(return_position_impl_trait_in_trait)]
-#![feature(associated_type_defaults)]
 
 pub mod gateway;
 pub mod request;

--- a/discord/src/lib.rs
+++ b/discord/src/lib.rs
@@ -1,5 +1,3 @@
-#![feature(return_position_impl_trait_in_trait)]
-
 pub mod gateway;
 pub mod request;
 pub mod resource;

--- a/discord/src/message.rs
+++ b/discord/src/message.rs
@@ -4,9 +4,9 @@ use partial_id::Partial;
 use serde::{Deserialize, Serialize};
 use serde_repr::{Deserialize_repr, Serialize_repr};
 
-use crate::resource::resource;
+use crate::resource::{resource, Endpoint};
 
-use super::request::{Discord, Request};
+use super::request::{Discord, HttpRequest};
 use super::{channel::Channel, resource::Snowflake, user::PartialUser};
 
 #[derive(Debug, Deserialize, Copy, Clone, PartialEq, Eq)]
@@ -196,8 +196,8 @@ struct CreateThread {
     name: String,
 }
 
-impl MessageIdentifier {
-    pub fn uri(&self) -> String {
+impl Endpoint for MessageIdentifier {
+    fn uri(&self) -> String {
         format!(
             "/channels/{}/messages/{}",
             self.channel_id.as_int(),
@@ -211,17 +211,17 @@ resource! {
     use Discord;
 
     fn get(&self) -> Message {
-        Request::get(self.endpoint().uri())
+        HttpRequest::get(self.endpoint().uri())
     }
     fn patch(&self, data: PatchMessage) -> Message {
-        Request::patch(self.endpoint().uri(), &data)
+        HttpRequest::patch(self.endpoint().uri(), &data)
     }
     fn delete(mut self) -> () {
-        Request::delete(self.endpoint().uri())
+        HttpRequest::delete(self.endpoint().uri())
     }
 
     fn start_thread(&self, name: String) -> Channel {
-        Request::post(
+        HttpRequest::post(
             format!("{}/threads", self.endpoint().uri()),
             &CreateThread { name },
         )

--- a/discord/src/message.rs
+++ b/discord/src/message.rs
@@ -1,18 +1,13 @@
-use async_trait::async_trait;
 use derive_setters::Setters;
 use monostate::MustBe;
 use partial_id::Partial;
 use serde::{Deserialize, Serialize};
 use serde_repr::{Deserialize_repr, Serialize_repr};
 
-use crate::resource::Endpoint;
+use crate::resource::resource;
 
-use super::request::{Discord, Request, Result};
-use super::{
-    channel::Channel,
-    resource::{Resource, Snowflake},
-    user::PartialUser,
-};
+use super::request::{Discord, Request};
+use super::{channel::Channel, resource::Snowflake, user::PartialUser};
 
 #[derive(Debug, Deserialize, Copy, Clone, PartialEq, Eq)]
 pub struct MessageIdentifier {
@@ -201,36 +196,8 @@ struct CreateThread {
     name: String,
 }
 
-#[async_trait]
-pub trait MessageResource: Resource<Endpoint = MessageIdentifier> {
-    fn channel(&self) -> Snowflake<Channel> {
-        self.endpoint().channel_id
-    }
-
-    fn start_thread_request(&self, name: String) -> Request<Channel> {
-        let id = self.endpoint();
-        Request::post(
-            format!(
-                "/channels/{}/messages/{}/threads",
-                id.channel_id.as_int(),
-                id.message_id.as_int()
-            ),
-            &CreateThread { name },
-        )
-    }
-    async fn start_thread(&self, client: &Discord, name: String) -> Result<Channel> {
-        self.start_thread_request(name).request(client).await
-    }
-}
-
-impl<T> MessageResource for T where T: Resource<Endpoint = MessageIdentifier> {}
-
-impl Endpoint for MessageIdentifier {
-    type Result = Message;
-    type Patch = PatchMessage;
-    type Delete = ();
-
-    fn uri(&self) -> String {
+impl MessageIdentifier {
+    pub fn uri(&self) -> String {
         format!(
             "/channels/{}/messages/{}",
             self.channel_id.as_int(),
@@ -239,15 +206,35 @@ impl Endpoint for MessageIdentifier {
     }
 }
 
-impl Resource for Message {
-    type Endpoint = MessageIdentifier;
-    fn endpoint(&self) -> &Self::Endpoint {
+resource! {
+    MessageResource as MessageIdentifier;
+    use Discord;
+
+    fn get(&self) -> Message {
+        Request::get(self.endpoint().uri())
+    }
+    fn patch(&self, data: PatchMessage) -> Message {
+        Request::patch(self.endpoint().uri(), &data)
+    }
+    fn delete(mut self) -> () {
+        Request::delete(self.endpoint().uri())
+    }
+
+    fn start_thread(&self, name: String) -> Channel {
+        Request::post(
+            format!("{}/threads", self.endpoint().uri()),
+            &CreateThread { name },
+        )
+    }
+}
+
+impl MessageResource for Message {
+    fn endpoint(&self) -> &MessageIdentifier {
         &self.id
     }
 }
-impl Resource for PartialMessage {
-    type Endpoint = MessageIdentifier;
-    fn endpoint(&self) -> &Self::Endpoint {
+impl MessageResource for PartialMessage {
+    fn endpoint(&self) -> &MessageIdentifier {
         &self.id
     }
 }

--- a/discord/src/request.rs
+++ b/discord/src/request.rs
@@ -45,41 +45,53 @@ pub enum RequestError {
 pub type Result<T> = ::std::result::Result<T, RequestError>;
 
 impl<T: DeserializeOwned, C: Client + ?Sized> Request<T, C> {
-    pub fn get(uri: String) -> Self {
+    pub fn get<S>(uri: S) -> Self
+    where
+        S: Into<String>,
+    {
         Request {
             phantom: PhantomData,
             method: Method::GET,
-            uri,
+            uri: uri.into(),
             body: None,
             map: |t| t,
         }
     }
 
-    pub fn post(uri: String, body: &impl Serialize) -> Self {
+    pub fn post<S>(uri: S, body: &impl Serialize) -> Self
+    where
+        S: Into<String>,
+    {
         Request {
             phantom: PhantomData,
             method: Method::POST,
-            uri,
+            uri: uri.into(),
             body: Some(serde_json::to_string(body).unwrap()),
             map: |t| t,
         }
     }
 
-    pub fn patch(uri: String, body: &impl Serialize) -> Self {
+    pub fn patch<S>(uri: S, body: &impl Serialize) -> Self
+    where
+        S: Into<String>,
+    {
         Request {
             phantom: PhantomData,
             method: Method::PATCH,
-            uri,
+            uri: uri.into(),
             body: Some(serde_json::to_string(body).unwrap()),
             map: |t| t,
         }
     }
 
-    pub fn delete(uri: String) -> Self {
+    pub fn delete<S>(uri: S) -> Self
+    where
+        S: Into<String>,
+    {
         Request {
             phantom: PhantomData,
             method: Method::DELETE,
-            uri,
+            uri: uri.into(),
             body: None,
             map: |t| t,
         }

--- a/discord/src/resource.rs
+++ b/discord/src/resource.rs
@@ -1,18 +1,33 @@
 use std::{
     any::type_name,
-    convert::Infallible,
     fmt,
     hash::{Hash, Hasher},
     marker::PhantomData,
     num::ParseIntError,
 };
 
-use async_trait::async_trait;
-use serde::{de::DeserializeOwned, Deserialize, Serialize};
+use serde::{Deserialize, Serialize};
 
-use crate::request::Client;
-
-use super::request::{Discord, Request, Result};
+macro_rules! resource {
+    { $trait_name:ident $(<$($gen:ident)+>)? as $endpoint:ty $(where $($where:ident : $wheretyp:ty)+)?; use $client:ty; $(fn $func_name:ident ($ref:tt $self:ident $(, $name:ident : $ty:ty)*) -> $ret:ty $impl:block)+ } => {
+        #[::async_trait::async_trait]
+        pub trait $trait_name $(<$($gen)+>)? : Sized $(where $($where : $wheretyp)+)? {
+            fn endpoint(&self) -> &$endpoint;
+            $(
+                async fn $func_name(#[allow(unused_mut)] $ref $self, client: &$client $(, $name : $ty)*) -> $crate::request::Result<$ret> {
+                    let req = $impl;
+                    $crate::request::Request::request(req, client).await
+                }
+            )+
+        }
+        impl $(<$($gen)+>)? $trait_name $(<$($gen)+>)? for $endpoint $(where $($where : $wheretyp)+)? {
+            fn endpoint(&self) -> &$endpoint {
+                self
+            }
+        }
+    };
+}
+pub(crate) use resource;
 
 #[derive(Deserialize, Serialize)]
 #[serde(try_from = "String", into = "String")]
@@ -76,174 +91,4 @@ impl<T> fmt::Debug for Snowflake<T> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.write_fmt(format_args!("<{}> {}", type_name::<T>(), self.id))
     }
-}
-
-pub trait Endpoint {
-    type Result: DeserializeOwned;
-    type Get: DeserializeOwned = Self::Result;
-
-    type Delete = Infallible;
-    type Patch = Infallible;
-    type Create = Infallible;
-
-    type Client: Client + ?Sized = Discord;
-    fn uri(&self) -> String;
-}
-
-impl<T> Resource for T
-where
-    T: Endpoint,
-{
-    type Endpoint = Self;
-
-    fn endpoint(&self) -> &Self::Endpoint {
-        self
-    }
-}
-
-#[async_trait]
-pub trait Resource {
-    type Endpoint: Endpoint;
-
-    fn endpoint(&self) -> &Self::Endpoint;
-
-    fn get_request(
-        &self,
-    ) -> Request<<Self::Endpoint as Endpoint>::Get, <Self::Endpoint as Endpoint>::Client> {
-        Request::get(self.endpoint().uri())
-    }
-
-    async fn get(
-        &self,
-        client: &<Self::Endpoint as Endpoint>::Client,
-    ) -> Result<<Self::Endpoint as Endpoint>::Get> {
-        self.get_request().request(client).await
-    }
-}
-
-#[async_trait]
-pub trait Updatable
-where
-    Self: Resource + Sized + Sync,
-    <Self::Endpoint as Endpoint>::Get: Into<Self>,
-{
-    async fn update(&mut self, client: &<Self::Endpoint as Endpoint>::Client) -> Result<()> {
-        *self = self.get(client).await?.into();
-        Ok(())
-    }
-}
-
-impl<T> Updatable for T
-where
-    T: Resource + Sync,
-    <T::Endpoint as Endpoint>::Get: Into<T>,
-{
-}
-
-#[async_trait]
-pub trait Patchable
-where
-    Self: Resource,
-    <Self::Endpoint as Endpoint>::Patch: Default + Serialize,
-{
-    fn patch_request(
-        &self,
-        f: impl FnOnce(<Self::Endpoint as Endpoint>::Patch) -> <Self::Endpoint as Endpoint>::Patch,
-    ) -> Request<<Self::Endpoint as Endpoint>::Result, <Self::Endpoint as Endpoint>::Client> {
-        let builder = f(<Self::Endpoint as Endpoint>::Patch::default());
-        Request::patch(self.endpoint().uri(), &builder)
-    }
-
-    async fn patch(
-        &self,
-        client: &<Self::Endpoint as Endpoint>::Client,
-        f: impl FnOnce(<Self::Endpoint as Endpoint>::Patch) -> <Self::Endpoint as Endpoint>::Patch
-            + Send,
-    ) -> Result<<Self::Endpoint as Endpoint>::Result> {
-        self.patch_request(f).request(client).await
-    }
-}
-
-impl<T> Patchable for T
-where
-    T: Resource,
-    <T::Endpoint as Endpoint>::Patch: Default + Serialize,
-{
-}
-
-#[async_trait]
-pub trait Editable
-where
-    Self: Patchable + Sized + Sync,
-    <Self::Endpoint as Endpoint>::Patch: Default + Serialize,
-    <Self::Endpoint as Endpoint>::Result: Into<Self>,
-{
-    async fn edit(
-        &mut self,
-        client: &<Self::Endpoint as Endpoint>::Client,
-        f: impl FnOnce(<Self::Endpoint as Endpoint>::Patch) -> <Self::Endpoint as Endpoint>::Patch
-            + Send,
-    ) -> Result<()> {
-        *self = self.patch(client, f).await?.into();
-        Ok(())
-    }
-}
-
-impl<T> Editable for T
-where
-    T: Patchable + Sync,
-    <T::Endpoint as Endpoint>::Patch: Default + Serialize,
-    <T::Endpoint as Endpoint>::Result: Into<T>,
-{
-}
-
-#[async_trait]
-pub trait Deletable
-where
-    Self: Resource + Sized,
-    Self::Endpoint: Endpoint<Delete = ()>,
-{
-    fn delete_request(self) -> Request<(), <Self::Endpoint as Endpoint>::Client> {
-        Request::delete(self.endpoint().uri())
-    }
-
-    async fn delete(self, client: &<Self::Endpoint as Endpoint>::Client) -> Result<()> {
-        self.delete_request().request(client).await
-    }
-}
-
-impl<T> Deletable for T
-where
-    T: Resource,
-    T::Endpoint: Endpoint<Delete = ()>,
-{
-}
-
-#[async_trait]
-pub trait Creatable
-where
-    Self: Resource,
-    <Self::Endpoint as Endpoint>::Create: Serialize + Sync,
-{
-    fn create_request(
-        &self,
-        create: &<Self::Endpoint as Endpoint>::Create,
-    ) -> Request<<Self::Endpoint as Endpoint>::Result, <Self::Endpoint as Endpoint>::Client> {
-        Request::post(self.endpoint().uri(), create)
-    }
-
-    async fn create(
-        &self,
-        client: &<Self::Endpoint as Endpoint>::Client,
-        create: &<Self::Endpoint as Endpoint>::Create,
-    ) -> Result<<Self::Endpoint as Endpoint>::Result> {
-        self.create_request(create).request(client).await
-    }
-}
-
-impl<T> Creatable for T
-where
-    T: Resource,
-    <T::Endpoint as Endpoint>::Create: Serialize + Sync,
-{
 }

--- a/discord/src/resource.rs
+++ b/discord/src/resource.rs
@@ -9,9 +9,9 @@ use std::{
 use serde::{Deserialize, Serialize};
 
 macro_rules! resource {
-    { $trait_name:ident $(<$($gen:ident)+>)? as $endpoint:ty $(where $($where:ident : $wheretyp:ty)+)?; use $client:ty; $(fn $func_name:ident ($ref:tt $self:ident $(, $name:ident : $ty:ty)*) -> $ret:ty $impl:block)+ } => {
+    { $trait_name:ident as $endpoint:ty; use $client:ty; $(fn $func_name:ident ($ref:tt $self:ident $(, $name:ident : $ty:ty)*) -> $ret:ty $impl:block)+ } => {
         #[::async_trait::async_trait]
-        pub trait $trait_name $(<$($gen)+>)? : Sized $(where $($where : $wheretyp)+)? {
+        pub trait $trait_name: Sized {
             fn endpoint(&self) -> &$endpoint;
             $(
                 async fn $func_name(#[allow(unused_mut)] $ref $self, client: &$client $(, $name : $ty)*) -> $crate::request::Result<$ret> {
@@ -20,7 +20,7 @@ macro_rules! resource {
                 }
             )+
         }
-        impl $(<$($gen)+>)? $trait_name $(<$($gen)+>)? for $endpoint $(where $($where : $wheretyp)+)? {
+        impl $trait_name for $endpoint {
             fn endpoint(&self) -> &$endpoint {
                 self
             }
@@ -28,6 +28,10 @@ macro_rules! resource {
     };
 }
 pub(crate) use resource;
+
+pub trait Endpoint {
+    fn uri(&self) -> String;
+}
 
 #[derive(Deserialize, Serialize)]
 #[serde(try_from = "String", into = "String")]

--- a/discord/src/resource.rs
+++ b/discord/src/resource.rs
@@ -8,26 +8,7 @@ use std::{
 
 use serde::{Deserialize, Serialize};
 
-macro_rules! resource {
-    { $trait_name:ident as $endpoint:ty; use $client:ty; $(fn $func_name:ident ($ref:tt $self:ident $(, $name:ident : $ty:ty)*) -> $ret:ty $impl:block)+ } => {
-        #[::async_trait::async_trait]
-        pub trait $trait_name: Sized {
-            fn endpoint(&self) -> &$endpoint;
-            $(
-                async fn $func_name(#[allow(unused_mut)] $ref $self, client: &$client $(, $name : $ty)*) -> $crate::request::Result<$ret> {
-                    let req = $impl;
-                    $crate::request::Request::request(req, client).await
-                }
-            )+
-        }
-        impl $trait_name for $endpoint {
-            fn endpoint(&self) -> &$endpoint {
-                self
-            }
-        }
-    };
-}
-pub(crate) use resource;
+pub use resource::resource;
 
 pub trait Endpoint {
     fn uri(&self) -> String;

--- a/discord/src/user.rs
+++ b/discord/src/user.rs
@@ -5,10 +5,10 @@ use partial_id::Partial;
 use serde::{Deserialize, Serialize};
 
 use crate::guild::PartialGuild;
-use crate::resource::resource;
+use crate::resource::{resource, Endpoint};
 
 use super::request::Discord;
-use super::{channel::Channel, request::Request, resource::Snowflake};
+use super::{channel::Channel, request::HttpRequest, resource::Snowflake};
 
 #[derive(Partial)]
 #[derive(Debug, Deserialize)]
@@ -23,8 +23,8 @@ impl Display for Snowflake<User> {
     }
 }
 
-impl Snowflake<User> {
-    pub fn uri(&self) -> String {
+impl Endpoint for Snowflake<User> {
+    fn uri(&self) -> String {
         format!("/users/{}", self.as_int())
     }
 }
@@ -45,11 +45,11 @@ resource! {
     use Discord;
 
     fn get(&self) -> User {
-        Request::get(self.endpoint().uri())
+        HttpRequest::get(self.endpoint().uri())
     }
 
     fn create_dm(&self) -> Channel {
-        Request::post(
+        HttpRequest::post(
             "/users/@me/channels",
             &DMRequest {
                 recipient_id: self.endpoint().clone(),
@@ -76,13 +76,13 @@ resource! {
     use Discord;
 
     fn get(&self) -> User {
-        Request::get("/users/@me")
+        HttpRequest::get("/users/@me")
     }
     fn patch(&self, data: PatchUser) -> User {
-        Request::patch("/users/@me", &data)
+        HttpRequest::patch("/users/@me", &data)
     }
 
     fn get_guilds(&self) -> Vec<PartialGuild> {
-        Request::get("/users/@me/guilds")
+        HttpRequest::get("/users/@me/guilds")
     }
 }

--- a/src/game/mod.rs
+++ b/src/game/mod.rs
@@ -11,8 +11,8 @@ use discord::{
     channel::ChannelResource,
     interaction::{
         ApplicationCommand, ComponentInteractionResource, CreateReply, CreateUpdate, Interaction,
-        InteractionResource, InteractionResponseIdentifier, InteractionResponseResource,
-        InteractionToken, MessageComponent, ReplyFlag, Webhook,
+        InteractionResource, InteractionResponseIdentifier, InteractionToken, MessageComponent,
+        ReplyFlag, Webhook,
     },
     message::{
         ActionRow, Author, CreateMessage, Embed, Field, Message, MessageResource, PatchMessage,

--- a/src/main.rs
+++ b/src/main.rs
@@ -116,7 +116,7 @@ async fn run() -> Result<()> {
     println!("GUILDS");
     for guild in guilds.iter_mut() {
         purge(application.guild_commands(guild), &client).await?;
-        println!(" - {}", guild.name.as_ref().cloned().unwrap());
+        println!(" - {}", guild.get_field(&client, |g| &g.name).await?);
     }
 
     // create commands

--- a/src/main.rs
+++ b/src/main.rs
@@ -11,14 +11,14 @@ use discord::interaction::{
     AnyInteraction, CreateReply, InteractionResource, MessageComponent, Webhook,
 };
 use discord::request::Discord;
-use discord::user::{self, MeResource, User};
+use discord::user::{self, User};
 use dotenv::dotenv;
 use futures_util::StreamExt;
 use game::{Flow, Game, GameMessage, GameUI, InteractionDispatcher, Logic};
 
-use discord::application::{self, ApplicationMeResource, ApplicationResource};
+use discord::application::{self, ApplicationResource};
 use discord::command::CommandData;
-use discord::command::{CommandResource, Commands, CommandsResource};
+use discord::command::{CommandResource, Commands};
 use discord::gateway::Gateway;
 use discord::gateway::GatewayEvent;
 use discord::interaction::Interaction;


### PR DESCRIPTION
Currently, Resource and Endpoint are big traits with lots of generics. At this point the rust language server often fails giving autocomplete options for these. Hence we should turn this into a macro.