### PR TITLE
Prepare for a breaking change in the Rust compiler.

### DIFF
--- a/discord/partial_id/src/lib.rs
+++ b/discord/partial_id/src/lib.rs
@@ -117,7 +117,7 @@ pub fn derive_partial(input: proc_macro::TokenStream) -> proc_macro::TokenStream
                 *self = ::core::convert::Into::into(full);
                 crate::request::Result::Ok(())
             }
-            #vis async fn get_field<T>(&mut self, client: &crate::request::Bot, f: fn(&Self) -> &::core::option::Option<T>) -> crate::request::Result<&T> {
+            #vis async fn get_field<'a, T: 'a>(&'a mut self, client: &crate::request::Bot, f: fn(&Self) -> &::core::option::Option<T>) -> crate::request::Result<&'a T> {
                 crate::request::Result::Ok(match f(self) {
                     ::core::option::Option::Some(_) => {
                         f(self).as_ref().unwrap()


### PR DESCRIPTION
The soundness fix in rust-lang/rust#115008 will cause `discord` to break, even though it is not unsound. The missing bound is very hard to abuse, but still a soundness hole in our type system.

It will likely take 12 weeks before a stable compiler with the soundness fix is shipped.